### PR TITLE
Ignore warnings from lib-folder

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,7 @@
   via_ir = false
   ffi = true
 
+ignored_warnings_from = ["lib"]
 remappings = [
   "forge-std/=lib/forge-std/src/",
   "@openzeppelin-contracts/=lib/openzeppelin-contracts-upgradeable/lib/openzeppelin-contracts/",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to ignore warnings from the "lib" directory during build or test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->