### PR TITLE
feat: added stake checking during eigen operator registration

### DIFF
--- a/script/SetupContract.s.sol
+++ b/script/SetupContract.s.sol
@@ -112,9 +112,10 @@ contract SetupContract is Script, Test {
         IStrategy[] memory strategies = new IStrategy[](1);
         strategies[0] = IStrategy(wethStrategyAddr);
 
-        uint32 validatorOperatorSetId = eigenLayerMiddleware.createOperatorSet(strategies);
+        uint32 validatorOperatorSetId =
+            eigenLayerMiddleware.createOperatorSet(strategies, 0);
         uint32 underwriterOperatorSetId =
-            eigenLayerMiddleware.createOperatorSet(strategies);
+            eigenLayerMiddleware.createOperatorSet(strategies, 0);
 
         OperatorSet memory opSet;
         opSet.id = validatorOperatorSetId;

--- a/src/eigenlayer-avs/EigenLayerMiddleware.sol
+++ b/src/eigenlayer-avs/EigenLayerMiddleware.sol
@@ -237,13 +237,16 @@ contract EigenLayerMiddleware is
     /// @notice Creates an operator set with the given strategies
     /// @param strategies Array of strategies for the operator set
     /// @return operatorSetId The ID of the created operator set
-    function createOperatorSet(IStrategy[] memory strategies)
+    function createOperatorSet(
+        IStrategy[] memory strategies,
+        uint256 minStake
+    )
         external
         onlyOwner
         returns (uint32 operatorSetId)
     {
         return EigenLayerMiddlewareLib.createOperatorSet(
-            ALLOCATION_MANAGER, address(this), REGISTRY_COORDINATOR, strategies
+            ALLOCATION_MANAGER, address(this), REGISTRY_COORDINATOR, strategies, minStake
         );
     }
 

--- a/src/interfaces/IEigenLayerMiddleware.sol
+++ b/src/interfaces/IEigenLayerMiddleware.sol
@@ -112,8 +112,14 @@ interface IEigenLayerMiddleware {
 
     /// @notice Create a new operator set with specified strategies
     /// @param strategies Array of strategy contracts
+    /// @param minStake The minimum stake required for the operator set
     /// @return The ID of the newly created operator set
-    function createOperatorSet(IStrategy[] memory strategies) external returns (uint32);
+    function createOperatorSet(
+        IStrategy[] memory strategies,
+        uint256 minStake
+    )
+        external
+        returns (uint32);
 
     /// @notice Add strategies to an existing operator set
     /// @param operatorSetId The ID of the operator set

--- a/src/interfaces/ITaiyiRegistryCoordinator.sol
+++ b/src/interfaces/ITaiyiRegistryCoordinator.sol
@@ -162,11 +162,13 @@ interface ITaiyiRegistryCoordinator {
 
     /// @notice Create a new operator set with the specified strategies
     /// @param subnetworkId The ID of the subnetwork
-    function createSubnetwork(uint96 subnetworkId) external;
+    /// @param minStake The minimum stake required for the subnetwork
+    function createSubnetwork(uint96 subnetworkId, uint256 minStake) external;
 
     /// @notice Create a new operator set with the specified strategies
     /// @param operatorSetId The ID of the operator set
-    function createOperatorSet(uint32 operatorSetId) external;
+    /// @param minStake The minimum stake required for the operator set
+    function createOperatorSet(uint32 operatorSetId, uint256 minStake) external;
 
     /// @notice Gets the protocol type for a middleware address
     /// @param middleware The middleware address to query

--- a/src/libs/EigenLayerMiddlewareLib.sol
+++ b/src/libs/EigenLayerMiddlewareLib.sol
@@ -260,7 +260,8 @@ library EigenLayerMiddlewareLib {
         address allocationManager,
         address avsAddress,
         ITaiyiRegistryCoordinator registryCoordinator,
-        IStrategy[] memory strategies
+        IStrategy[] memory strategies,
+        uint256 minStake
     )
         internal
         returns (uint32 operatorSetId)
@@ -288,7 +289,7 @@ library EigenLayerMiddlewareLib {
             avsAddress, createSetParams
         );
 
-        registryCoordinator.createOperatorSet(operatorSetId);
+        registryCoordinator.createOperatorSet(operatorSetId, minStake);
 
         return operatorSetId;
     }

--- a/src/libs/OperatorSubsetLib.sol
+++ b/src/libs/OperatorSubsetLib.sol
@@ -40,8 +40,12 @@ library OperatorSubsetLib {
         EnumerableSet.UintSet operatorSetIds32; // For 32-bit IDs
         // set id to operator address mapping for 96-bit IDs
         mapping(uint96 => EnumerableSet.AddressSet) sets96;
+        // set id => minStake mapping for 96-bit IDs
+        mapping(uint96 => uint256) minStake96;
         // set id to operator address mapping for 32-bit IDs
         mapping(uint32 => EnumerableSet.AddressSet) sets32;
+        // set id => minStake mapping for 32-bit IDs
+        mapping(uint32 => uint256) minStake32;
     }
 
     /// @notice Encodes a protocol type and base ID into a single ID using uint96 (5 bits protocol, 91 bits baseId)
@@ -226,11 +230,13 @@ library OperatorSubsetLib {
     /// @return Success boolean
     function createOperatorSet96(
         OperatorSets storage operatorSets,
-        uint96 encodedId
+        uint96 encodedId,
+        uint256 minStake
     )
         internal
         returns (bool)
     {
+        operatorSets.minStake96[encodedId] = minStake;
         return operatorSets.operatorSetIds96.add(uint256(encodedId));
     }
 
@@ -238,14 +244,17 @@ library OperatorSubsetLib {
     /// @dev Uses uint32 for smaller operator set IDs
     /// @param operatorSets The storage reference to operator sets mapping
     /// @param encodedId The encoded operator set ID as uint32
+    /// @param minStake The minimum stake required for the operator set
     /// @return Success boolean
     function createOperatorSet32(
         OperatorSets storage operatorSets,
-        uint32 encodedId
+        uint32 encodedId,
+        uint256 minStake
     )
         internal
         returns (bool)
     {
+        operatorSets.minStake32[encodedId] = minStake;
         return operatorSets.operatorSetIds32.add(uint256(encodedId));
     }
 
@@ -622,5 +631,31 @@ library OperatorSubsetLib {
         } else {
             revert OperatorSetLib__OperatorSetDoesNotExist();
         }
+    }
+
+    /* ========== MIN STAKE HELPERS ========== */
+
+    /// @notice Returns the minimum stake required for a uint32 operator set
+    function getMinStake32(
+        OperatorSets storage operatorSets,
+        uint32 encodedId
+    )
+        internal
+        view
+        returns (uint256)
+    {
+        return operatorSets.minStake32[encodedId];
+    }
+
+    /// @notice Returns the minimum stake required for a uint96 operator set
+    function getMinStake96(
+        OperatorSets storage operatorSets,
+        uint96 encodedId
+    )
+        internal
+        view
+        returns (uint256)
+    {
+        return operatorSets.minStake96[encodedId];
     }
 }

--- a/src/operator-registries/PubkeyRegistry.sol
+++ b/src/operator-registries/PubkeyRegistry.sol
@@ -68,9 +68,8 @@ contract PubkeyRegistry is PubkeyRegistryStorage, IPubkeyRegistry {
 
         return ecrecover(_ethSignedMessageHash, v, r, s);
     }
-    // Todo: remove bypass in test mode
-    /// @inheritdoc IPubkeyRegistry
 
+    /// @inheritdoc IPubkeyRegistry
     function registerBLSPublicKey(
         address operator,
         PubkeyRegistrationParams calldata params

--- a/src/symbiotic-network/SymbioticNetworkMiddleware.sol
+++ b/src/symbiotic-network/SymbioticNetworkMiddleware.sol
@@ -119,13 +119,20 @@ contract SymbioticNetworkMiddleware is
     // ==============================================================================================
 
     /// @notice Creates a new subnetwork with the given ID
+    /// @param minStake The minimum stake required for the subnetwork
     /// @param baseSubnetworkId The ID of the base subnetwork to create
-    function createNewSubnetwork(uint96 baseSubnetworkId) external checkAccess {
+    function createNewSubnetwork(
+        uint96 baseSubnetworkId,
+        uint256 minStake
+    )
+        external
+        checkAccess
+    {
         uint96 encodedSubnetworkId = baseSubnetworkId.encodeOperatorSetId96(
             ITaiyiRegistryCoordinator.RestakingProtocol.SYMBIOTIC
         );
         super._registerSubnetwork(encodedSubnetworkId);
-        REGISTRY_COORDINATOR.createSubnetwork(encodedSubnetworkId);
+        REGISTRY_COORDINATOR.createSubnetwork(encodedSubnetworkId, minStake);
         SUBNETWORK_COUNT = SUBNETWORK_COUNT + 1;
     }
 

--- a/test/EigenLayerMiddleware.t.sol
+++ b/test/EigenLayerMiddleware.t.sol
@@ -454,8 +454,8 @@ contract EigenlayerMiddlewareTest is Test, G2Operations {
 
         // Create the operator set directly through middleware
         vm.startPrank(owner);
-        validatorOperatorSetId = middleware.createOperatorSet(strategies);
-        underwriterOperatorSetId = middleware.createOperatorSet(strategies);
+        validatorOperatorSetId = middleware.createOperatorSet(strategies, 0);
+        underwriterOperatorSetId = middleware.createOperatorSet(strategies, 0);
         vm.stopPrank();
 
         console.log("Created validator operator set with ID:", validatorOperatorSetId);

--- a/test/OperatorSubsetLib.t.sol
+++ b/test/OperatorSubsetLib.t.sol
@@ -177,16 +177,16 @@ contract OperatorSubsetLibTest is Test {
             OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_2, PROTOCOL_2);
 
         assertTrue(
-            operatorSets.createOperatorSet96(encodedId96_1), "Create set 96_1 failed"
+            operatorSets.createOperatorSet96(encodedId96_1, 0), "Create set 96_1 failed"
         );
         assertTrue(
-            operatorSets.createOperatorSet96(encodedId96_2), "Create set 96_2 failed"
+            operatorSets.createOperatorSet96(encodedId96_2, 0), "Create set 96_2 failed"
         );
         assertTrue(
-            operatorSets.createOperatorSet32(encodedId32_1), "Create set 32_1 failed"
+            operatorSets.createOperatorSet32(encodedId32_1, 0), "Create set 32_1 failed"
         );
         assertTrue(
-            operatorSets.createOperatorSet32(encodedId32_2), "Create set 32_2 failed"
+            operatorSets.createOperatorSet32(encodedId32_2, 0), "Create set 32_2 failed"
         );
     }
 
@@ -209,10 +209,10 @@ contract OperatorSubsetLibTest is Test {
         uint32 encodedId32_2 =
             OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_2, PROTOCOL_1);
 
-        operatorSets.createOperatorSet96(encodedId96_1);
-        operatorSets.createOperatorSet96(encodedId96_2);
-        operatorSets.createOperatorSet32(encodedId32_1);
-        operatorSets.createOperatorSet32(encodedId32_2);
+        operatorSets.createOperatorSet96(encodedId96_1, 0);
+        operatorSets.createOperatorSet96(encodedId96_2, 0);
+        operatorSets.createOperatorSet32(encodedId32_1, 0);
+        operatorSets.createOperatorSet32(encodedId32_2, 0);
 
         uint96[] memory sets96 = operatorSets.getOperatorSets96();
         assertEq(sets96.length, 2, "Incorrect number of 96-bit sets returned");
@@ -242,7 +242,7 @@ contract OperatorSubsetLibTest is Test {
     function testAddOperatorToSet() public {
         // Test 96-bit set
         operatorSets.createOperatorSet96(
-            OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_1, PROTOCOL_1)
+            OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_1, PROTOCOL_1), 0
         );
         assertTrue(
             operatorSets.addOperatorToSet96(
@@ -268,7 +268,7 @@ contract OperatorSubsetLibTest is Test {
 
         // Test 32-bit set
         operatorSets.createOperatorSet32(
-            OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_1, PROTOCOL_1)
+            OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_1, PROTOCOL_1), 0
         );
         assertTrue(
             operatorSets.addOperatorToSet32(
@@ -338,7 +338,7 @@ contract OperatorSubsetLibTest is Test {
     function testRemoveOperatorFromSet() public {
         // Setup for 96-bit set
         operatorSets.createOperatorSet96(
-            OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_1, PROTOCOL_1)
+            OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_1, PROTOCOL_1), 0
         );
         operatorSets.addOperatorToSet96(
             OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_1, PROTOCOL_1),
@@ -351,7 +351,7 @@ contract OperatorSubsetLibTest is Test {
 
         // Setup for 32-bit set
         operatorSets.createOperatorSet32(
-            OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_1, PROTOCOL_1)
+            OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_1, PROTOCOL_1), 0
         );
         operatorSets.addOperatorToSet32(
             OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_1, PROTOCOL_1),
@@ -468,8 +468,8 @@ contract OperatorSubsetLibTest is Test {
             OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_2, PROTOCOL_1);
 
         // Create the sets first using encoded IDs
-        operatorSets.createOperatorSet96(encodedIds96[0]);
-        operatorSets.createOperatorSet96(encodedIds96[1]);
+        operatorSets.createOperatorSet96(encodedIds96[0], 0);
+        operatorSets.createOperatorSet96(encodedIds96[1], 0);
 
         // Setup for 32-bit sets
         uint32[] memory encodedIds32 = new uint32[](2);
@@ -479,8 +479,8 @@ contract OperatorSubsetLibTest is Test {
             OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_2, PROTOCOL_1);
 
         // Create the sets first using encoded IDs
-        operatorSets.createOperatorSet32(encodedIds32[0]);
-        operatorSets.createOperatorSet32(encodedIds32[1]);
+        operatorSets.createOperatorSet32(encodedIds32[0], 0);
+        operatorSets.createOperatorSet32(encodedIds32[1], 0);
 
         // Add operator to multiple sets using encoded IDs
         operatorSets.addOperatorToSets96(encodedIds96, PROTOCOL_1, OPERATOR_1);
@@ -518,8 +518,8 @@ contract OperatorSubsetLibTest is Test {
             OperatorSubsetLib.encodeOperatorSetId96(TEST_BASE_ID_2, PROTOCOL_1);
 
         // Create and populate 96-bit sets using encoded IDs
-        operatorSets.createOperatorSet96(encodedIds96[0]);
-        operatorSets.createOperatorSet96(encodedIds96[1]);
+        operatorSets.createOperatorSet96(encodedIds96[0], 0);
+        operatorSets.createOperatorSet96(encodedIds96[1], 0);
         operatorSets.addOperatorToSet96(encodedIds96[0], OPERATOR_1);
         operatorSets.addOperatorToSet96(encodedIds96[1], OPERATOR_1);
 
@@ -535,8 +535,8 @@ contract OperatorSubsetLibTest is Test {
             OperatorSubsetLib.encodeOperatorSetId32(TEST_BASE_ID_32_2, PROTOCOL_1);
 
         // Create and populate 32-bit sets using encoded IDs
-        operatorSets.createOperatorSet32(encodedIds32[0]);
-        operatorSets.createOperatorSet32(encodedIds32[1]);
+        operatorSets.createOperatorSet32(encodedIds32[0], 0);
+        operatorSets.createOperatorSet32(encodedIds32[1], 0);
         operatorSets.addOperatorToSet32(encodedIds32[0], OPERATOR_1);
         operatorSets.addOperatorToSet32(encodedIds32[1], OPERATOR_1);
 

--- a/test/SymbioticMiddleware.t.sol
+++ b/test/SymbioticMiddleware.t.sol
@@ -535,8 +535,8 @@ contract SymbioticMiddlewareTest is POCBaseTest {
     }
 
     function _setupSubnetworks() internal impersonate(owner) {
-        middleware.createNewSubnetwork(VALIDATOR_SUBNETWORK);
-        middleware.createNewSubnetwork(UNDERWRITER_SUBNETWORK);
+        middleware.createNewSubnetwork(VALIDATOR_SUBNETWORK, 0);
+        middleware.createNewSubnetwork(UNDERWRITER_SUBNETWORK, 0);
 
         validatorSubnetworkId = VALIDATOR_SUBNETWORK;
         underwriterSubnetworkId = UNDERWRITER_SUBNETWORK;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a minimum stake requirement when creating operator sets and subnetworks.
  - Enforced minimum stake checks during EigenLayer operator registration to ensure compliance with stake requirements.

- **Tests**
  - Updated tests to accommodate the new minimum stake parameter in relevant function calls.

- **Documentation**
  - Enhanced interface documentation to describe the new minimum stake parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->