### PR TITLE
feat: extend linglong challenger interface

### DIFF
--- a/src/interfaces/ILinglongChallenger.sol
+++ b/src/interfaces/ILinglongChallenger.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { VerificationStatus } from "../types/CommonTypes.sol";
 import { IAllocationManagerTypes } from
     "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import { ISlasher } from "@urc/ISlasher.sol";
@@ -8,23 +9,6 @@ import { ISlasher } from "@urc/ISlasher.sol";
 /// @title ILinglongChallenger
 /// @notice Interface for the LinglongChallenger contract
 interface ILinglongChallenger {
-    /// @notice Challenge status enum
-    /// @dev Used to track the current status of a challenge
-    enum ChallengeStatus {
-        None,
-        Open,
-        Proven,
-        Disproven
-    }
-
-    /// @notice Verification status enum
-    /// @dev Used to indicate the status of proof verification
-    enum VerificationStatus {
-        None,
-        Verified,
-        Invalid
-    }
-
     /// @notice Event emitted when a new challenge is initiated
     /// @param challengeId Unique ID of the challenge
     /// @param registrationRoot Registration root of the challenged validator
@@ -58,7 +42,6 @@ interface ILinglongChallenger {
     /// @return status The status of the verification
     function verifyProof(bytes memory payload)
         external
-        view
         returns (VerificationStatus status);
 
     /// @notice Initiates a challenge against an operator for a specific commitment
@@ -74,6 +57,7 @@ interface ILinglongChallenger {
         bytes calldata signature
     )
         external
+        payable
         returns (bytes32);
 
     /// @notice Resolves a challenge

--- a/src/interfaces/ITaiyiInteractiveChallenger.sol
+++ b/src/interfaces/ITaiyiInteractiveChallenger.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { ChallengeStatus } from "../types/CommonTypes.sol";
+
+import { VerificationStatus } from "../types/CommonTypes.sol";
 import { PreconfRequestAType } from "../types/PreconfRequestATypes.sol";
 import { PreconfRequestBType } from "../types/PreconfRequestBTypes.sol";
 
 interface ITaiyiInteractiveChallenger {
-    enum ChallengeStatus {
-        Open,
-        Failed,
-        Succeded
-    }
-
     struct Challenge {
         bytes32 id;
         uint256 createdAt;
@@ -39,12 +36,6 @@ interface ITaiyiInteractiveChallenger {
     error CommitmentSignerDoesNotMatch();
     error BlockHashDoesNotMatch();
 
-    event ChallengeOpened(
-        bytes32 indexed id, address indexed challenger, address indexed commitmentSigner
-    );
-    event ChallengeFailed(bytes32 indexed id);
-    event ChallengeSucceded(bytes32 indexed id);
-
     /// @notice Get all challenges.
     /// @return challenges An array of challenges.
     function getChallenges() external view returns (Challenge[] memory);
@@ -58,26 +49,6 @@ interface ITaiyiInteractiveChallenger {
     /// @return challenge The challenge.
     function getChallenge(bytes32 id) external view returns (Challenge memory);
 
-    /// @notice Create a new challenge.
-    /// @param preconfRequestAType The type A preconf request.
-    /// @param signature The signature over the commitment data.
-    function createChallengeAType(
-        PreconfRequestAType calldata preconfRequestAType,
-        bytes calldata signature
-    )
-        external
-        payable;
-
-    /// @notice Create a new challenge.
-    /// @param preconfRequestBType The type B preconf request.
-    /// @param signature The signature over the commitment data.
-    function createChallengeBType(
-        PreconfRequestBType calldata preconfRequestBType,
-        bytes calldata signature
-    )
-        external
-        payable;
-
     /// @notice Resolve an expired challenge.
     /// @dev This function can be called by anyone to resolve an expired challenge.
     /// @param id The id of the expired challenge.
@@ -90,15 +61,4 @@ interface ITaiyiInteractiveChallenger {
     /// @notice Set the verification key for the interactive fraud proof program.
     /// @param _interactiveFraudProofVKey The verification key.
     function setInteractiveFraudProofVKey(bytes32 _interactiveFraudProofVKey) external;
-
-    /// @notice The entrypoint for defending against an open challenge using a SP1 proof of execution.
-    /// @param id The id of the challenge to defend against.
-    /// @param proofValues The encoded public values.
-    /// @param proofBytes The encoded proof.
-    function prove(
-        bytes32 id,
-        bytes calldata proofValues,
-        bytes calldata proofBytes
-    )
-        external;
 }

--- a/src/slasher/LinglongSlasher.sol
+++ b/src/slasher/LinglongSlasher.sol
@@ -29,6 +29,7 @@ import { ITaiyiRegistryCoordinator } from "../interfaces/ITaiyiRegistryCoordinat
 
 import { OperatorSubsetLib } from "../libs/OperatorSubsetLib.sol";
 import { LinglongSlasherStorage } from "../storage/LinglongSlasherStorage.sol";
+import { VerificationStatus } from "../types/CommonTypes.sol";
 
 /// @title LinglongSlasher
 /// @notice Implementation of the ILinglongSlasher interface that bridges between URC's slashing system
@@ -363,8 +364,7 @@ contract LinglongSlasher is Initializable, OwnableUpgradeable, LinglongSlasherSt
         bytes memory payload
     )
         internal
-        view
-        returns (ILinglongChallenger.VerificationStatus)
+        returns (VerificationStatus)
     {
         // Decode the original payload for verification
         (bytes memory decodedPayload) = abi.decode(payload, (bytes));
@@ -416,10 +416,9 @@ contract LinglongSlasher is Initializable, OwnableUpgradeable, LinglongSlasherSt
         returns (bool)
     {
         // First verify the proof
-        ILinglongChallenger.VerificationStatus status =
-            _verifyChallenger(challengerContract, payload);
+        VerificationStatus status = _verifyChallenger(challengerContract, payload);
 
-        if (status != ILinglongChallenger.VerificationStatus.Verified) {
+        if (status != VerificationStatus.Verified) {
             revert ProofVerificationFailed();
         }
 
@@ -479,10 +478,9 @@ contract LinglongSlasher is Initializable, OwnableUpgradeable, LinglongSlasherSt
         returns (bool)
     {
         // First verify the proof
-        ILinglongChallenger.VerificationStatus status =
-            _verifyChallenger(challengerContract, payload);
+        VerificationStatus status = _verifyChallenger(challengerContract, payload);
 
-        if (status != ILinglongChallenger.VerificationStatus.Verified) {
+        if (status != VerificationStatus.Verified) {
             revert ProofVerificationFailed();
         }
 

--- a/src/types/CommonTypes.sol
+++ b/src/types/CommonTypes.sol
@@ -21,3 +21,20 @@ struct DelegationStore {
     // index -> validator pubKey Hash
     EnumerableMapLib.Uint256ToBytes32Map delegationMap;
 }
+
+/// @notice Challenge status enum
+/// @dev Used to track the current status of a challenge
+enum ChallengeStatus {
+    None,
+    Open,
+    Proven,
+    Disproven
+}
+
+/// @notice Verification status enum
+/// @dev Used to indicate the status of proof verification
+enum VerificationStatus {
+    None,
+    Verified,
+    Invalid
+}

--- a/test/EigenLayerMiddleware.t.sol
+++ b/test/EigenLayerMiddleware.t.sol
@@ -59,6 +59,7 @@ import { SocketRegistry } from "src/operator-registries/SocketRegistry.sol";
 import { TaiyiRegistryCoordinator } from
     "src/operator-registries/TaiyiRegistryCoordinator.sol";
 import { LinglongSlasher } from "src/slasher/LinglongSlasher.sol";
+import { ChallengeStatus } from "src/types/CommonTypes.sol";
 
 contract EigenlayerMiddlewareTest is Test, G2Operations {
     using OperatorSubsetLib for uint32;
@@ -1169,7 +1170,7 @@ contract EigenlayerMiddlewareTest is Test, G2Operations {
             createdAt: block.timestamp,
             challenger: challenger,
             commitmentSigner: primaryOp,
-            status: ITaiyiInteractiveChallenger.ChallengeStatus.Open,
+            status: ChallengeStatus.Open,
             preconfType: 0,
             commitmentData: new bytes(0),
             signature: new bytes(0)

--- a/test/SymbioticMiddleware.t.sol
+++ b/test/SymbioticMiddleware.t.sol
@@ -38,6 +38,8 @@ import { IRegistry } from "@urc/IRegistry.sol";
 import { ISlasher } from "@urc/ISlasher.sol";
 import { Registry } from "@urc/Registry.sol";
 import { BLS } from "@urc/lib/BLS.sol";
+
+import { ChallengeStatus } from "../src/types/CommonTypes.sol";
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
@@ -271,7 +273,7 @@ contract SymbioticMiddlewareTest is POCBaseTest {
             createdAt: block.timestamp,
             challenger: challenger,
             commitmentSigner: operator,
-            status: ITaiyiInteractiveChallenger.ChallengeStatus.Open,
+            status: ChallengeStatus.Open,
             preconfType: 0,
             commitmentData: new bytes(0),
             signature: new bytes(0)

--- a/test/utils/MockChallenger.sol
+++ b/test/utils/MockChallenger.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.25;
 
 import { ILinglongChallenger } from "../../src/interfaces/ILinglongChallenger.sol";
+
+import { ChallengeStatus, VerificationStatus } from "../../src/types/CommonTypes.sol";
 import { IAllocationManagerTypes } from
     "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import { ISlasher } from "@urc/ISlasher.sol";
@@ -91,6 +93,7 @@ contract MockLinglongChallenger is ILinglongChallenger {
         bytes calldata signature
     )
         external
+        payable
         override
         returns (bytes32)
     {


### PR DESCRIPTION
Summary:
1. Moved `VerificationStatus` and `ChallengeStatus` to common types
2. Minor changes were made to the `ILinglongChallenger` interface
3. `TaiyiInteractiveChallenger` implements  `ILinglongChallenger`
4. `TaiyiInteractiveChallenger` tests updated so everything passes with the new types

Open questions:
1. Where/How can I get the operator registration root ? ([code link](https://github.com/martines3000/linglong/blob/5af42ec97b3ad85b71413f8979d6e1437bf907dd/src/taiyi/TaiyiInteractiveChallenger.sol#L200))
2. How should the `slashIds` be handled and can a operator have multiple slashings in progress at once ? ([code link](https://github.com/martines3000/linglong/blob/5af42ec97b3ad85b71413f8979d6e1437bf907dd/src/taiyi/TaiyiInteractiveChallenger.sol#L524))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added unified enums for challenge and verification statuses, standardizing status handling across the system.
	- Introduced new functions for challenge initiation, proof verification, and slashing state tracking.
	- Added new events for unified challenge initiation and resolution.
	- Enabled challenge initiation functions to receive Ether.

- **Refactor**
	- Updated interfaces and contracts to use shared enums and a more generic challenge initiation interface.
	- Consolidated and streamlined challenge creation and resolution logic.

- **Bug Fixes**
	- Corrected function modifiers and event emissions to align with new interface requirements.

- **Tests**
	- Updated tests to use the new challenge initiation and verification methods, and to accommodate the refactored status enums and events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->