### PR TITLE
fix: deployments

### DIFF
--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -424,7 +424,7 @@ contract Deploy is Script, Test {
     }
 
     function getPrivateKeys()
-        internal
+        public
         returns (uint256 proxyDeployerPrivateKey, uint256 implPrivateKey)
     {
         string memory pkString = vm.envString("PROXY_OWNER_PRIVATE_KEY");

--- a/script/Deployments.s.sol
+++ b/script/Deployments.s.sol
@@ -105,8 +105,11 @@ contract Deploy is Script, Test {
         DeployFromScratch deployFromScratch = new DeployFromScratch();
         deployFromScratch.run(configFileName);
 
-        string memory outputFile =
-            string(bytes("script/output/devnet/M2_from_scratch_deployment_data.json"));
+        string memory outputFile = string(
+            bytes(
+                "script/output/devnet/SLASHING_deploy_from_scratch_deployment_data.json"
+            )
+        );
         string memory output_data = vm.readFile(outputFile);
 
         // whitelist weth
@@ -209,6 +212,7 @@ contract Deploy is Script, Test {
                 implOwner,
                 0,
                 allocationManager,
+                address(deployedContracts.eigenLayerMiddleware),
                 eigenPauserReg
             )
         );

--- a/script/SetupContract.s.sol
+++ b/script/SetupContract.s.sol
@@ -88,8 +88,11 @@ contract SetupContract is Script, Test {
         LinglongSlasher linglongSlasher = LinglongSlasher(
             stdJson.readAddress(output_data, ".taiyiAddresses.linglongSlasher")
         );
-        string memory eigenLayerOutputFile =
-            string(bytes("script/output/devnet/M2_from_scratch_deployment_data.json"));
+        string memory eigenLayerOutputFile = string(
+            bytes(
+                "script/output/devnet/SLASHING_deploy_from_scratch_deployment_data.json"
+            )
+        );
 
         string memory eigenLayerOutput_data = vm.readFile(eigenLayerOutputFile);
         address wethStrategyAddr =

--- a/script/configs/deploy-test-config.json
+++ b/script/configs/deploy-test-config.json
@@ -1,0 +1,62 @@
+{
+    "maintainer": "samlaf@eigenlabs.org",
+    "multisig_addresses": {
+         "operationsMultisig": "0xD8F3183DEF51A987222D845be228e0Bbb932C222",
+         "communityMultisig": "0xD8F3183DEF51A987222D845be228e0Bbb932C222",
+         "pauserMultisig": "0xD8F3183DEF51A987222D845be228e0Bbb932C222",
+         "executorMultisig": "0xD8F3183DEF51A987222D845be228e0Bbb932C222",
+         "timelock": "0xD8F3183DEF51A987222D845be228e0Bbb932C222"
+    },
+    "strategies": [
+        {
+            "token_address": "0x86A4F08103eade88adE0be164d7BDa8Fe166680d",
+            "token_symbol": "WETH",
+            "max_per_deposit": 115792089237316195423570985008687907853269984665640564039457584007913129639935,
+            "max_deposits": 115792089237316195423570985008687907853269984665640564039457584007913129639935
+        }
+    ],
+    "strategyManager": {
+        "init_paused_status": 0,
+        "init_withdrawal_delay_blocks": 1
+    },
+    "eigenPod": {
+        "PARTIAL_WITHDRAWAL_FRAUD_PROOF_PERIOD_BLOCKS": 1,
+        "MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR": "32000000000"
+    },
+    "eigenPodManager": {
+        "init_paused_status": 30
+    },
+    "delayedWithdrawalRouter": {
+        "init_paused_status": 0,
+        "init_withdrawal_delay_blocks": 1
+    },
+    "slasher": {
+        "init_paused_status": 0
+    },
+    "delegation": {
+        "withdrawal_delay_blocks": 900,
+        "init_paused_status": 0,
+        "init_withdrawal_delay_blocks": 1
+    },
+    "rewardsCoordinator": {
+        "init_paused_status": 0,
+        "CALCULATION_INTERVAL_SECONDS": 604800,
+        "MAX_REWARDS_DURATION": 6048000,
+        "MAX_RETROACTIVE_LENGTH": 7776000,
+        "MAX_FUTURE_LENGTH": 2592000,
+        "GENESIS_REWARDS_TIMESTAMP": 1710979200,
+        "rewards_updater_address": "0x18a0f92Ad9645385E8A8f3db7d0f6CF7aBBb0aD4",
+        "activation_delay": 7200,
+        "calculation_interval_seconds": 604800,
+        "global_operator_commission_bips": 1000,
+        "OPERATOR_SET_GENESIS_REWARDS_TIMESTAMP": 1720656000,
+        "OPERATOR_SET_MAX_RETROACTIVE_LENGTH": 2592000
+    },
+    "allocationManager": {
+        "init_paused_status": 0,
+        "DEALLOCATION_DELAY": 900,
+        "ALLOCATION_CONFIGURATION_DELAY": 1
+   },
+    "ethPOSDepositAddress": "0x4242424242424242424242424242424242424242",
+    "semver": "v0.0.0"
+  }

--- a/script/configs/eigenlayer-deploy-config-devnet.json
+++ b/script/configs/eigenlayer-deploy-config-devnet.json
@@ -34,6 +34,7 @@
         "init_paused_status": 0
     },
     "delegation": {
+        "withdrawal_delay_blocks": 900,
         "init_paused_status": 0,
         "init_withdrawal_delay_blocks": 1
     },
@@ -47,7 +48,7 @@
         "rewards_updater_address": "0x18a0f92Ad9645385E8A8f3db7d0f6CF7aBBb0aD4",
         "activation_delay": 7200,
         "calculation_interval_seconds": 604800,
-        "default_operator_split_bips": 1000,
+        "global_operator_commission_bips": 1000,
         "OPERATOR_SET_GENESIS_REWARDS_TIMESTAMP": 1720656000,
         "OPERATOR_SET_MAX_RETROACTIVE_LENGTH": 2592000
     },
@@ -56,5 +57,6 @@
         "DEALLOCATION_DELAY": 900,
         "ALLOCATION_CONFIGURATION_DELAY": 1
    },
-    "ethPOSDepositAddress": "0x4242424242424242424242424242424242424242"
+    "ethPOSDepositAddress": "0x4242424242424242424242424242424242424242",
+    "semver": "v0.0.0"
   }

--- a/script/setup-contract.sh
+++ b/script/setup-contract.sh
@@ -13,10 +13,11 @@ if [ -z "$NETWORK" ]; then
     export NETWORK="devnet"
 fi
 export FOUNDRY_PROFILE=ci
-forge script --rpc-url $EXECUTION_URL \
--vvvv --broadcast ./script/SetupContract.s.sol:SetupContract \
---sig "run()" \
 
 forge script --rpc-url $EXECUTION_URL \
 -vvvv --broadcast ./script/SetRegistry.s.sol:SetRegistry \
---sig "run()" \
+--sig "run()" 
+
+forge script --rpc-url $EXECUTION_URL \
+-vvvv --broadcast ./script/SetupContract.s.sol:SetupContract \
+--sig "run()" 

--- a/src/operator-registries/TaiyiRegistryCoordinator.sol
+++ b/src/operator-registries/TaiyiRegistryCoordinator.sol
@@ -112,6 +112,7 @@ contract TaiyiRegistryCoordinator is
         address initialOwner,
         uint256 initialPausedStatus,
         address _allocationManager,
+        address _eigenLayerMiddleware,
         address /* _pauserRegistry */
     )
         external
@@ -125,6 +126,12 @@ contract TaiyiRegistryCoordinator is
         if (_allocationManager != address(0)) {
             allocationManager = IAllocationManager(_allocationManager);
         }
+
+        require(
+            _eigenLayerMiddleware != address(0),
+            "EigenLayer middleware cannot be zero address"
+        );
+        eigenLayerMiddleware = _eigenLayerMiddleware;
     }
 
     // ==============================================================================================

--- a/src/operator-registries/TaiyiRegistryCoordinator.sol
+++ b/src/operator-registries/TaiyiRegistryCoordinator.sol
@@ -127,11 +127,9 @@ contract TaiyiRegistryCoordinator is
             allocationManager = IAllocationManager(_allocationManager);
         }
 
-        require(
-            _eigenLayerMiddleware != address(0),
-            "EigenLayer middleware cannot be zero address"
-        );
-        eigenLayerMiddleware = _eigenLayerMiddleware;
+        if (_eigenLayerMiddleware != address(0)) {
+            eigenLayerMiddleware = _eigenLayerMiddleware;
+        }
     }
 
     // ==============================================================================================

--- a/test/DeployTest.t.sol
+++ b/test/DeployTest.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import { Deploy } from "../script/Deployments.s.sol";
+import { SetRegistry } from "../script/SetRegistry.s.sol";
+import { SetupContract } from "../script/SetupContract.s.sol";
+import "forge-std/Test.sol";
+
+contract DeployTest is Test {
+    Deploy deploy;
+    SetRegistry setRegistry;
+    SetupContract setupContract;
+
+    function setUp() public {
+        deploy = new Deploy();
+        setRegistry = new SetRegistry();
+        setupContract = new SetupContract();
+    }
+
+    function testRunDeployScript() public {
+        vm.setEnv(
+            "PROXY_OWNER_PRIVATE_KEY",
+            "c5114526e042343c6d1899cad05e1c00ba588314de9b96929914ee0df18d46b2"
+        );
+        vm.setEnv(
+            "IMPL_OWNER_PRIVATE_KEY",
+            "a492823c3e193d6c595f37a18e3c06650cf4c74558cc818b16130b293716106f"
+        );
+        vm.setEnv("NETWORK", "devnet");
+        (uint256 proxyDeployerPrivateKey, uint256 implPrivateKey) =
+            deploy.getPrivateKeys();
+        address deployer = vm.addr(proxyDeployerPrivateKey);
+        address implOwner = vm.addr(implPrivateKey);
+        vm.deal(deployer, 1000 ether);
+        vm.deal(implOwner, 1000 ether);
+
+        deploy.run("deploy-test-config.json");
+        setRegistry.run();
+        setupContract.run();
+    }
+}

--- a/test/EigenLayerMiddleware.t.sol
+++ b/test/EigenLayerMiddleware.t.sol
@@ -364,6 +364,7 @@ contract EigenlayerMiddlewareTest is Test, G2Operations {
             owner, // initialOwner
             0, // initialPausedStatus
             address(eigenLayerDeployer.allocationManager()), // _allocationManager
+            address(middleware),
             address(eigenLayerDeployer.eigenLayerPauserReg()) // _pauserRegistry
         );
 

--- a/test/SymbioticMiddleware.t.sol
+++ b/test/SymbioticMiddleware.t.sol
@@ -454,6 +454,8 @@ contract SymbioticMiddlewareTest is POCBaseTest {
             owner, // initialOwner
             0, // initialPausedStatus
             address(eigenLayerDeployer.allocationManager()), // _allocationManager
+            // require eigenlayer Middleware address, not useful in symbiotic so use any address but 0 for test to pass
+            address(eigenLayerDeployer.eigenLayerPauserReg()),
             address(eigenLayerDeployer.eigenLayerPauserReg()) // _pauserRegistry
         );
 


### PR DESCRIPTION
https://linear.app/luban-protocol/issue/LIN-39/update-taiyi-based-on-the-latest-linglong-changes-with-slashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit initialization of the EigenLayer middleware address during contract setup.
  - Introduced configuration options for delegation withdrawal delay and semantic versioning in deployment configs.
  - Added a new test contract simulating full deployment with controlled keys and funds.

- **Improvements**
  - Enhanced permission and admin setup during registry and contract initialization.
  - Updated naming for operator commission parameters in configuration for clarity.
  - Adjusted execution order of deployment scripts for improved setup flow.
  - Made deployment scripts use updated deployment data paths and include middleware address in initialization.

- **Bug Fixes**
  - Improved validation to prevent setting the EigenLayer middleware address to zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->