### PR TITLE
Fix typo in ITaiyiParameterManager.sol comment

### DIFF
--- a/src/interfaces/ITaiyiParameterManager.sol
+++ b/src/interfaces/ITaiyiParameterManager.sol
@@ -27,7 +27,7 @@ interface ITaiyiParameterManager {
     /// @param _challengeBond The bond required to open a challenge.
     function setChallengeBond(uint256 _challengeBond) external;
 
-    /// @notice Set the challenge maxiumum duration.
+    /// @notice Set the challenge maximum duration.
     /// @param _challengeMaxDuration The maximum duration of a challenge.
     function setChallengeMaxDuration(uint256 _challengeMaxDuration) external;
 


### PR DESCRIPTION


## Description

Fixed a typo in the documentation comment for the `setChallengeMaxDuration` function:
- **Before:** `/// @notice Set the challenge maxiumum duration.`
- **After:** `/// @notice Set the challenge maximum duration.`

## Changes

- Corrected spelling from "maxiumum" to "maximum" in line 30 of `src/interfaces/ITaiyiParameterManager.sol`

