### PR TITLE
chore: update GitHub actions

### DIFF
--- a/.github/workflows/foundry-ci.yml
+++ b/.github/workflows/foundry-ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Foundry Project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0